### PR TITLE
Adding merging functionality

### DIFF
--- a/lib/knapsack/adapters/base_adapter.rb
+++ b/lib/knapsack/adapters/base_adapter.rb
@@ -15,9 +15,15 @@ module Knapsack
         update_report_config
 
         if tracker.config[:generate_report]
-          Knapsack.logger.info 'Knapsack report generator started!'
-          bind_time_tracker
-          bind_report_generator
+          if tracker.config[:merge_report]
+            Knapsack.logger.info 'Knapsack report generator started! Will merge results into existing json'
+            bind_time_tracker
+            bind_merge_report
+          else
+            Knapsack.logger.info 'Knapsack report generator started!'
+            bind_time_tracker
+            bind_report_generator
+          end
         elsif tracker.config[:enable_time_offset_warning]
           Knapsack.logger.info 'Knapsack time offset warning enabled!'
           bind_time_tracker
@@ -39,6 +45,9 @@ module Knapsack
         raise NotImplementedError
       end
 
+      def bind_merge_report
+        raise NotImplementedError
+      end
       private
 
       def tracker

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -36,6 +36,14 @@ module Knapsack
         end
       end
 
+      def bind_merge_report
+        ::RSpec.configure do |config|
+          config.after(:suite) do
+            Knapsack.report.save_and_merge
+            Knapsack.logger.info(Presenter.report_details)
+          end
+        end
+      end
       def bind_time_offset_warning
         ::RSpec.configure do |config|
           config.after(:suite) do

--- a/lib/knapsack/config/tracker.rb
+++ b/lib/knapsack/config/tracker.rb
@@ -13,6 +13,10 @@ module Knapsack
         def generate_report
           !!(ENV['KNAPSACK_GENERATE_REPORT'] =~ /\Atrue|0\z/i)
         end
+
+        def merge_report
+          !!(ENV['KNAPSACK_MERGE_REPORT'] =~ /\Atrue|0\z/i)
+        end
       end
     end
   end

--- a/lib/knapsack/report.rb
+++ b/lib/knapsack/report.rb
@@ -21,6 +21,19 @@ module Knapsack
       end
     end
 
+    def save_and_merge
+      File.open(report_path, 'a+') do |f|
+          #read in the entire json into a variable, add the new one(s) into the hash, write the result
+      existing_times = JSON.parse(f.read.delete!("\n")).to_hash #convert file to hash so we can merge in
+      new_times = JSON.parse(report_json).to_hash unless report_json.nil?
+
+      existing_times = existing_times.merge(new_times) unless new_times.nil? || existing_times.nil?
+      final_copy = JSON.pretty_generate(existing_times)
+      
+      f.truncate(0) # clear existing content
+      f.write(final_copy)
+    end
+
     def open
       report = File.read(report_path)
       JSON.parse(report)

--- a/lib/knapsack/report.rb
+++ b/lib/knapsack/report.rb
@@ -24,14 +24,15 @@ module Knapsack
     def save_and_merge
       File.open(report_path, 'a+') do |f|
           #read in the entire json into a variable, add the new one(s) into the hash, write the result
-      existing_times = JSON.parse(f.read.delete!("\n")).to_hash #convert file to hash so we can merge in
-      new_times = JSON.parse(report_json).to_hash unless report_json.nil?
+        existing_times = JSON.parse(f.read.delete!("\n")).to_hash #convert file to hash so we can merge in
+        new_times = JSON.parse(report_json).to_hash unless report_json.nil?
 
-      existing_times = existing_times.merge(new_times) unless new_times.nil? || existing_times.nil?
-      final_copy = JSON.pretty_generate(existing_times)
-      
-      f.truncate(0) # clear existing content
-      f.write(final_copy)
+        existing_times = existing_times.merge(new_times) unless new_times.nil? || existing_times.nil?
+        final_copy = JSON.pretty_generate(existing_times)
+
+        f.truncate(0) # clear existing content
+        f.write(final_copy)
+      end
     end
 
     def open

--- a/lib/knapsack/tracker.rb
+++ b/lib/knapsack/tracker.rb
@@ -52,7 +52,7 @@ module Knapsack
       {
         enable_time_offset_warning: Config::Tracker.enable_time_offset_warning,
         time_offset_in_seconds: Config::Tracker.time_offset_in_seconds,
-        generate_report: Config::Tracker.generate_report
+        generate_report: Config::Tracker.generate_report,
         merge_report: Config::Tracker.merge_report
       }
     end

--- a/lib/knapsack/tracker.rb
+++ b/lib/knapsack/tracker.rb
@@ -53,6 +53,7 @@ module Knapsack
         enable_time_offset_warning: Config::Tracker.enable_time_offset_warning,
         time_offset_in_seconds: Config::Tracker.time_offset_in_seconds,
         generate_report: Config::Tracker.generate_report
+        merge_report: Config::Tracker.merge_report
       }
     end
 

--- a/spec/knapsack/tracker_spec.rb
+++ b/spec/knapsack/tracker_spec.rb
@@ -24,6 +24,7 @@ describe Knapsack::Tracker do
             enable_time_offset_warning: false,
             time_offset_in_seconds: 30,
             generate_report: true,
+	    merge_report: false,
             fake: true
           })
         end
@@ -37,7 +38,8 @@ describe Knapsack::Tracker do
         expect(tracker.config).to eql({
           enable_time_offset_warning: true,
           time_offset_in_seconds: 30,
-          generate_report: false
+          generate_report: false,
+	  merge_report: false
         })
       end
     end


### PR DESCRIPTION
With regards to this: https://github.com/ArturT/knapsack/issues/34

I've made it so that you can pass a flag to start generating a report and merge it with the existing json (rspec only, though extending the functionality shouldn't be so tough).
The flag is: KNAPSACK_MERGE_REPORT=true and is set with the KNAPSACK_GENERATE_REPORT flag

This addition does two things: 
If a new spec(s) is added, its/their runtime is added to the existing json
If it's run against the suite, the existing times will be overwritten with the new ones via hash merge, 'updating' them