### PR TITLE
Allow accepting file containing test files to run - add support for env var KNAPSACK_TEST_FILE_LIST_SOURCE_FILE

### DIFF
--- a/lib/knapsack/allocator_builder.rb
+++ b/lib/knapsack/allocator_builder.rb
@@ -36,7 +36,7 @@ module Knapsack
     end
 
     def test_file_list_source_file
-      Knapsack::Config::test_file_list_source_file
+      Knapsack::Config::Env.test_file_list_source_file
     end
   end
 end

--- a/lib/knapsack/allocator_builder.rb
+++ b/lib/knapsack/allocator_builder.rb
@@ -9,6 +9,7 @@ module Knapsack
       Knapsack::Allocator.new({
         report: Knapsack.report.open,
         test_file_pattern: test_file_pattern,
+        test_file_list_source_file: test_file_list_source_file,
         ci_node_total: Knapsack::Config::Env.ci_node_total,
         ci_node_index: Knapsack::Config::Env.ci_node_index
       })
@@ -32,6 +33,10 @@ module Knapsack
 
     def test_file_pattern
       Knapsack::Config::Env.test_file_pattern || @adapter_class::TEST_DIR_PATTERN
+    end
+
+    def test_file_list_source_file
+      Knapsack::Config::test_file_list_source_file
     end
   end
 end

--- a/lib/knapsack/config/env.rb
+++ b/lib/knapsack/config/env.rb
@@ -18,6 +18,10 @@ module Knapsack
           ENV['KNAPSACK_TEST_FILE_PATTERN']
         end
 
+        def test_file_list_source_file
+          ENV['KNAPSACK_TEST_FILE_LIST_SOURCE_FILE']
+        end
+
         def test_dir
           ENV['KNAPSACK_TEST_DIR']
         end

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -45,12 +45,17 @@ module Knapsack
       # support specifying a list_file to use similar to KnapsackPro
       # ref: KnapsackPro/knapsack_pro-ruby/commit/7d7b8db8be524f2f30d7d80d3a6444dad9f85b1b
       def test_files
-        return Dir.glob(test_file_pattern).uniq.sort if test_file_list_source_file.nil?
+        default = Dir.glob(test_file_pattern).uniq.sort
 
-        File.read(test_file_list_source_file)
+        return default if test_file_list_source_file.nil?
+
+        test_file_list = File.read(test_file_list_source_file)
           .split(/\n/)
           .uniq
           .sort
+
+        return default if test_file_list.empty?
+        return test_file_list
       end
 
       protected

--- a/lib/knapsack/distributors/base_distributor.rb
+++ b/lib/knapsack/distributors/base_distributor.rb
@@ -1,11 +1,12 @@
 module Knapsack
   module Distributors
     class BaseDistributor
-      attr_reader :report, :node_tests, :test_file_pattern
+      attr_reader :report, :node_tests, :test_file_pattern, :test_file_list_source_file
 
       def initialize(args={})
         @report = args[:report] || raise('Missing report')
         @test_file_pattern = args[:test_file_pattern] || raise('Missing test_file_pattern')
+        @test_file_list_source_file = args[:test_file_list_source_file]
         @ci_node_total = args[:ci_node_total] || raise('Missing ci_node_total')
         @ci_node_index = args[:ci_node_index] || raise('Missing ci_node_index')
 
@@ -37,7 +38,19 @@ module Knapsack
       end
 
       def all_tests
-        @all_tests ||= Dir.glob(test_file_pattern).uniq.sort
+        @all_tests ||= test_files
+      end
+
+      # NOTE: Use the test_file_pattern by default
+      # support specifying a list_file to use similar to KnapsackPro
+      # ref: KnapsackPro/knapsack_pro-ruby/commit/7d7b8db8be524f2f30d7d80d3a6444dad9f85b1b
+      def test_files
+        return Dir.glob(test_file_pattern).uniq.sort if test_file_list_source_file.nil?
+
+        File.read(test_file_list_source_file)
+          .split(/\n/)
+          .uniq
+          .sort
       end
 
       protected

--- a/lib/knapsack/runners/cucumber_runner.rb
+++ b/lib/knapsack/runners/cucumber_runner.rb
@@ -12,6 +12,10 @@ module Knapsack
         Knapsack.logger.info allocator.leftover_node_tests
         Knapsack.logger.info
 
+        # NOTE: return if there are no specs to execute for this node.
+        # This can occurr if test_file_list_source_file is used with less then CI_NODES specs
+        return Knapsack.logger.warn('No specs to execute') if allocator.stringify_node_tests.empty?
+
         cmd = %Q[bundle exec cucumber #{args} --require #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)

--- a/lib/knapsack/runners/minitest_runner.rb
+++ b/lib/knapsack/runners/minitest_runner.rb
@@ -12,6 +12,10 @@ module Knapsack
         Knapsack.logger.info allocator.leftover_node_tests
         Knapsack.logger.info
 
+        # NOTE: return if there are no specs to execute for this node.
+        # This can occurr if test_file_list_source_file is used with less then CI_NODES specs
+        return Knapsack.logger.warn('No specs to execute') if allocator.stringify_node_tests.empty?
+
         task_name = 'knapsack:minitest_run'
 
         if Rake::Task.task_defined?(task_name)

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -5,12 +5,19 @@ module Knapsack
         allocator = Knapsack::AllocatorBuilder.new(Knapsack::Adapters::RSpecAdapter).allocator
 
         Knapsack.logger.info
+        puts ''
         Knapsack.logger.info 'Report specs:'
+        puts 'Report specs:'
         Knapsack.logger.info allocator.report_node_tests
+        puts allocator.report_node_tests
         Knapsack.logger.info
+        puts ''
         Knapsack.logger.info 'Leftover specs:'
+        puts 'Leftover specs:'
         Knapsack.logger.info allocator.leftover_node_tests
+        puts allocator.leftover_node_tests
         Knapsack.logger.info
+        puts
 
         # NOTE: return if there are no specs to execute for this node.
         # This can occurr if test_file_list_source_file is used with less then CI_NODES specs

--- a/lib/knapsack/runners/rspec_runner.rb
+++ b/lib/knapsack/runners/rspec_runner.rb
@@ -12,6 +12,10 @@ module Knapsack
         Knapsack.logger.info allocator.leftover_node_tests
         Knapsack.logger.info
 
+        # NOTE: return if there are no specs to execute for this node.
+        # This can occurr if test_file_list_source_file is used with less then CI_NODES specs
+        return Knapsack.logger.warn('No specs to execute') if allocator.stringify_node_tests.empty?
+
         cmd = %Q[bundle exec rspec #{args} --default-path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         exec(cmd)

--- a/lib/knapsack/runners/spinach_runner.rb
+++ b/lib/knapsack/runners/spinach_runner.rb
@@ -12,6 +12,10 @@ module Knapsack
         Knapsack.logger.info allocator.leftover_node_tests
         Knapsack.logger.info
 
+        # NOTE: return if there are no specs to execute for this node.
+        # This can occurr if test_file_list_source_file is used with less then CI_NODES specs
+        return Knapsack.logger.warn('No specs to execute') if allocator.stringify_node_tests.empty?
+
         cmd = %Q[bundle exec spinach #{args} --features_path #{allocator.test_dir} -- #{allocator.stringify_node_tests}]
 
         system(cmd)

--- a/spec/fixtures/test_file_list_source_file.txt
+++ b/spec/fixtures/test_file_list_source_file.txt
@@ -1,0 +1,5 @@
+./spec/test1_spec.rb
+spec/test2_spec.rb[1]
+./spec/test3_spec.rb[1:2:3:4]
+./spec/test4_spec.rb:4
+./spec/test4_spec.rb:5

--- a/spec/knapsack/allocator_builder_spec.rb
+++ b/spec/knapsack/allocator_builder_spec.rb
@@ -12,6 +12,7 @@ describe Knapsack::AllocatorBuilder do
   let(:env_ci_node_index) { double }
   let(:env_report_path) { nil }
   let(:env_test_file_pattern) { nil }
+  let(:env_test_file_list_source_file) { nil }
 
   describe '#allocator' do
     subject { allocator_builder.allocator }
@@ -19,6 +20,7 @@ describe Knapsack::AllocatorBuilder do
     before do
       expect(Knapsack::Config::Env).to receive(:report_path).and_return(env_report_path)
       expect(Knapsack::Config::Env).to receive(:test_file_pattern).and_return(env_test_file_pattern)
+      expect(Knapsack::Config::Env).to receive(:test_file_list_source_file).and_return(env_test_file_list_source_file)
       expect(Knapsack::Config::Env).to receive(:ci_node_total).and_return(env_ci_node_total)
       expect(Knapsack::Config::Env).to receive(:ci_node_index).and_return(env_ci_node_index)
 
@@ -36,6 +38,7 @@ describe Knapsack::AllocatorBuilder do
           {
             report: report,
             test_file_pattern: adapter_test_file_pattern,
+            test_file_list_source_file: env_test_file_list_source_file,
             ci_node_total: env_ci_node_total,
             ci_node_index: env_ci_node_index
           }
@@ -51,6 +54,7 @@ describe Knapsack::AllocatorBuilder do
           {
             report: report,
             test_file_pattern: adapter_test_file_pattern,
+            test_file_list_source_file: env_test_file_list_source_file,
             ci_node_total: env_ci_node_total,
             ci_node_index: env_ci_node_index
           }
@@ -66,6 +70,23 @@ describe Knapsack::AllocatorBuilder do
           {
             report: report,
             test_file_pattern: env_test_file_pattern,
+            test_file_list_source_file: env_test_file_list_source_file,
+            ci_node_total: env_ci_node_total,
+            ci_node_index: env_ci_node_index
+          }
+        end
+
+        it { should eql allocator }
+      end
+
+      context 'when ENV test_file_list_source_file has value' do
+        let(:env_test_file_list_source_file) { 'knapsack_custom_file_list.txt' }
+        let(:report_config) { { report_path: adapter_report_path } }
+        let(:allocator_args) do
+          {
+            report: report,
+            test_file_pattern: adapter_test_file_pattern,
+            test_file_list_source_file: env_test_file_list_source_file,
             ci_node_total: env_ci_node_total,
             ci_node_index: env_ci_node_index
           }

--- a/spec/knapsack/config/env_spec.rb
+++ b/spec/knapsack/config/env_spec.rb
@@ -122,6 +122,20 @@ describe Knapsack::Config::Env do
     end
   end
 
+  describe '.test_file_list_source_file' do
+    subject { described_class.test_file_list_source_file }
+
+    context 'when ENV exists' do
+      let(:test_file_list_source_file) { 'spec/fixtures/test_file_list_source_file.txt' }
+      before { stub_const("ENV", { 'KNAPSACK_TEST_FILE_LIST_SOURCE_FILE' => test_file_list_source_file }) }
+      it { should eql test_file_list_source_file }
+    end
+
+    context "when ENV doesn't exist" do
+      it { should be_nil }
+    end
+  end
+
   describe '.test_dir' do
     subject { described_class.test_dir }
 

--- a/spec/knapsack/distributors/leftover_distributor_spec.rb
+++ b/spec/knapsack/distributors/leftover_distributor_spec.rb
@@ -8,10 +8,12 @@ describe Knapsack::Distributors::LeftoverDistributor do
     }
   end
   let(:test_file_pattern) { 'spec/**{,/*/**}/*_spec.rb' }
+  let(:test_file_list_source_file) { nil }
   let(:default_args) do
     {
       report: report,
       test_file_pattern: test_file_pattern,
+      test_file_list_source_file: test_file_list_source_file,
       ci_node_total: '1',
       ci_node_index: '0'
     }
@@ -45,6 +47,21 @@ describe Knapsack::Distributors::LeftoverDistributor do
         it { should_not be_empty }
         it { should include 'spec_examples/fast/1_spec.rb' }
         it { should include 'spec_examples/leftover/a_spec.rb' }
+
+        it 'has no duplicated test file paths' do
+          expect(subject.size).to eq subject.uniq.size
+        end
+      end
+    end
+
+    context 'when given test_file_list_source_file' do
+      context 'spec/fixtures/test_file_list_source_file.txt' do
+        let(:test_file_list_source_file) { 'spec/fixtures/test_file_list_source_file.txt' }
+        it { should_not be_empty }
+        it { should include './spec/test3_spec.rb[1:2:3:4]' }
+        it { should include './spec/test4_spec.rb:5' }
+        it { should_not include 'spec/knapsack/tracker_spec.rb' }
+        it { should_not include 'spec/knapsack/adapters/rspec_adapter_spec.rb' }
 
         it 'has no duplicated test file paths' do
           expect(subject.size).to eq subject.uniq.size


### PR DESCRIPTION
ref: https://github.com/KnapsackPro/knapsack_pro-ruby/pull/129

This *PR* adds support for this behavior to the regular `knapsack` gem. 