### PR TITLE
Track time in before and after :context

### DIFF
--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -6,6 +6,10 @@ module Knapsack
 
       def bind_time_tracker
         ::RSpec.configure do |config|
+          config.prepend_before(:context) do
+            Knapsack.tracker.start_timer
+          end
+
           config.prepend_before(:each) do
             current_example_group =
               if ::RSpec.respond_to?(:current_example)
@@ -14,10 +18,9 @@ module Knapsack
                 example.metadata
               end
             Knapsack.tracker.test_path = RSpecAdapter.test_path(current_example_group)
-            Knapsack.tracker.start_timer
           end
 
-          config.append_after(:each) do
+          config.append_after(:context) do
             Knapsack.tracker.stop_timer
           end
 

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -24,8 +24,9 @@ describe Knapsack::Adapters::RSpecAdapter do
       end
 
       it do
+        expect(config).to receive(:prepend_before).with(:context).and_yield
         expect(config).to receive(:prepend_before).with(:each).and_yield
-        expect(config).to receive(:append_after).with(:each).and_yield
+        expect(config).to receive(:append_after).with(:context).and_yield
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 
@@ -33,10 +34,9 @@ describe Knapsack::Adapters::RSpecAdapter do
         expect(described_class).to receive(:test_path).with(example_group).and_return(test_path)
 
         allow(Knapsack).to receive(:tracker).and_return(tracker)
-        expect(tracker).to receive(:test_path=).with(test_path)
-        expect(tracker).to receive(:start_timer)
-
-        expect(tracker).to receive(:stop_timer)
+        expect(tracker).to receive(:start_timer).ordered
+        expect(tracker).to receive(:test_path=).with(test_path).ordered
+        expect(tracker).to receive(:stop_timer).ordered
 
         expect(Knapsack::Presenter).to receive(:global_time).and_return(global_time)
         expect(logger).to receive(:info).with(global_time)


### PR DESCRIPTION
This PR changes the start and end of the timer to be done in `prepend_before(:context)` and `append_after(:context)` so that the time tracked by Knapsack includes time spent in `before(:context)` and `after(:context)`.

Closes https://github.com/KnapsackPro/knapsack/issues/106

Given a spec file as follows:

```rb
RSpec.describe 'Foo' do
  context 'when something' do
    before(:context) do
      sleep(5)
    end

    before do
      sleep(0.1)
    end

    it 'test_1' do
      sleep(0.2)
      expect(true).to be_truthy
    end

    it 'test_2' do
      sleep(0.3)
      expect(true).to be_truthy
    end
  end
end
```

```shell
Finished in 5.72 seconds (files took 0.74649 seconds to load)
2 examples, 0 failures
```

The test takes a total of 5.7 seconds (5 + 2*0.1 + 0.2 + 0.3), as recorded by RSpec. Knapsack should also track this file as 5.7 seconds.