### PR TITLE
Fix a bug with tracking time for pending specs in RSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 1.21.1
+
+* Fix a bug with tracking time for pending specs in RSpec
+
+    https://github.com/KnapsackPro/knapsack/pull/109
+
+https://github.com/KnapsackPro/knapsack/compare/v1.21.0...v1.21.1
+
 ### 1.21.0
 
 * Track time in before and after `:context` hooks

--- a/lib/knapsack/tracker.rb
+++ b/lib/knapsack/tracker.rb
@@ -23,15 +23,19 @@ module Knapsack
     end
 
     def stop_timer
-      @execution_time = now_without_mock_time.to_f - @start_time
-      update_global_time
-      update_test_file_time
-      @execution_time
+      execution_time = now_without_mock_time.to_f - @start_time
+
+      if test_path
+        update_global_time(execution_time)
+        update_test_file_time(execution_time)
+        @test_path = nil
+      end
+
+      execution_time
     end
 
     def test_path
-      raise("test_path needs to be set by Knapsack Adapter's bind method") unless @test_path
-      @test_path.sub(/^\.\//, '')
+      @test_path.sub(/^\.\//, '') if @test_path
     end
 
     def time_exceeded?
@@ -62,13 +66,13 @@ module Knapsack
       @test_path = nil
     end
 
-    def update_global_time
-      @global_time += @execution_time
+    def update_global_time(execution_time)
+      @global_time += execution_time
     end
 
-    def update_test_file_time
+    def update_test_file_time(execution_time)
       @test_files_with_time[test_path] ||= 0
-      @test_files_with_time[test_path] += @execution_time
+      @test_files_with_time[test_path] += execution_time
     end
 
     def report_distributor

--- a/spec/knapsack/tracker_spec.rb
+++ b/spec/knapsack/tracker_spec.rb
@@ -48,7 +48,7 @@ describe Knapsack::Tracker do
 
     context 'when test_path not set' do
       it do
-        expect { subject }.to raise_error("test_path needs to be set by Knapsack Adapter's bind method")
+        expect(subject).to be_nil
       end
     end
 
@@ -133,6 +133,9 @@ describe Knapsack::Tracker do
       it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
       it { expect(tracker.test_files_with_time['a_spec.rb']).to be_within(delta).of(0.1) }
       it { expect(tracker.test_files_with_time['b_spec.rb']).to be_within(delta).of(0.2) }
+      it 'resets test_path after time is measured' do
+        expect(tracker.test_path).to be_nil
+      end
     end
 
     context "with Timecop - Timecop shouldn't have impact on measured test time" do
@@ -157,6 +160,9 @@ describe Knapsack::Tracker do
       it { expect(tracker.test_files_with_time.keys.size).to eql 2 }
       it { expect(tracker.test_files_with_time['a_spec.rb']).to be_within(delta).of(0) }
       it { expect(tracker.test_files_with_time['b_spec.rb']).to be_within(delta).of(0) }
+      it 'resets test_path after time is measured' do
+        expect(tracker.test_path).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Don't track time execution for not defined test path (for instance when test file has only pending examples and then we can't detect test path)

# Related
https://github.com/KnapsackPro/knapsack/issues/108