### PR TITLE
Reverts #77 with the minimal ruby version 2.1+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,7 @@ script:
 
   - bin/print_header.sh "Check passing arguments to minitest. Run verbose tests"
   - KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake "knapsack:minitest[--verbose]"
-  - if [ "$TRAVIS_RUBY_VERSION" == "1.9.3" ]; then KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose"; fi
-  - if [ "$TRAVIS_RUBY_VERSION" != "1.9.3" ]; then KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose --pride"; fi
+  - KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bin/knapsack minitest "--verbose --pride"
 
   - bin/print_header.sh "Run tests with custom knapsack logger"
   - CUSTOM_LOGGER=true KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake knapsack:minitest

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency 'rake', '>= 0'
 

--- a/test_examples/fast/shared_examples_test.rb
+++ b/test_examples/fast/shared_examples_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Minitest::SharedExamples < Module
-  include Minitest::Spec::DSL if RUBY_VERSION != "1.9.3"
+  include Minitest::Spec::DSL
 end
 
 SharedExampleSpec = Minitest::SharedExamples.new do

--- a/test_examples/test_helper.rb
+++ b/test_examples/test_helper.rb
@@ -2,15 +2,6 @@ require 'minitest/autorun'
 
 require 'knapsack'
 
-if RUBY_VERSION == "1.9.3"
-  unless defined? Minitest
-    Minitest = MiniTest
-  end
-  unless defined? Minitest::Test
-    Minitest::Test = MiniTest::Unit::TestCase
-  end
-end
-
 Knapsack.tracker.config({
   enable_time_offset_warning: true,
   time_offset_in_seconds: 3


### PR DESCRIPTION
Reverts #77 with dumping the minimal ruby version from 1.9.3 to 2.1+.

de491d6f67d977de8b34d79f32ade32d5db01013 dropped 1.9 support from CI in 2015-07 (6 years ago).

Revert "Merge pull request #77 from nicolasleger/ruby-1-9"

This reverts commit 754f0f5b6eb7e2ee7e7c58aafc3a9b39ed118bb0, reversing
changes made to 96a0eeb929653232224c889fefdaf7e8ace8b2d5.

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>

## Why Ruby 2.1+?

https://github.com/KnapsackPro/docs.knapsackpro.com/blob/5fe2c9460fe36939d145ff07e9ac8b21848d7399/docs/ruby/knapsack/readme.md#requirements says:

> `>= Ruby 2.1.0`
