### PR TITLE
Force to use minitest 5.x even on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ addons:
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 script:
+  # We nedd minitest 5.x
+  - (ruby -v | grep 'ruby 2.1' && gem install minitest -v 5.12.0 || exit 1) || true
   # Test for knapsack gem
   - bin/print_header.sh "Run specs for Knapsack gem"
   - bundle exec rspec spec

--- a/lib/knapsack/adapters/minitest_adapter.rb
+++ b/lib/knapsack/adapters/minitest_adapter.rb
@@ -23,20 +23,20 @@ module Knapsack
       def bind_time_tracker
         ::Minitest::Test.send(:include, BindTimeTrackerMinitestPlugin)
 
-        add_post_run_callback do
+        Minitest.after_run do
           Knapsack.logger.info(Presenter.global_time)
         end
       end
 
       def bind_report_generator
-        add_post_run_callback do
+        Minitest.after_run do
           Knapsack.report.save
           Knapsack.logger.info(Presenter.report_details)
         end
       end
 
       def bind_time_offset_warning
-        add_post_run_callback do
+        Minitest.after_run do
           Knapsack.logger.log(
             Presenter.time_offset_log_level,
             Presenter.time_offset_warning
@@ -63,16 +63,6 @@ module Knapsack
         test_path = full_test_path.gsub(parent_of_test_dir_regexp, '.')
         # test_path will look like ./test/dir/unit_test.rb
         test_path
-      end
-
-      private
-
-      def add_post_run_callback(&block)
-        if Minitest.respond_to?(:after_run)
-          Minitest.after_run { block.call }
-        else
-          Minitest::Unit.after_tests { block.call }
-        end
       end
     end
   end


### PR DESCRIPTION
## What
Forces to use minitest 5.x on CI (even with Ruby 2.1 or earlier).

## Why
The tweak for minitest 4 (which had been bundled with Ruby 1.9 through 2.1) introduced in #26 does bad. We expected minitest 5 in #16, but we could not have been using minitest 5.x on CI (with Ruby 2.1 or earlier).

Blocks #112

Signed-off-by: Takuya Noguchi <takninnovationresearch@gmail.com>