### PR TITLE
Require minimum Ruby 2.2 version

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   test:
@@ -14,12 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', truffleruby-head]
-        # Use minitest 5.12.0 on Ruby 2.1 (which has bundled minitest 4.x)
-        # (Note: minitest 5.12.1+ supports only Ruby 2.2+)
-        include:
-          - ruby: 2.1
-            minitest: 5.12.0
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', truffleruby-head]
 
     steps:
     - uses: actions/checkout@v2
@@ -28,11 +23,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-
-    # Use the latest minitest gem on Ruby 2.1
-    - name: Install minitest v5
-      if: ${{ matrix.minitest }}
-      run: gem install -N minitest -v ${{ matrix.minitest }}
 
     # Test for knapsack gem
     - name: Run specs for Knapsack gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### 3.0.0
 
+* (breaking change) Require minimum Ruby 2.2 version
+
+    https://github.com/KnapsackPro/knapsack/pull/115
+
 * (breaking change) Drop support for Minitest 4.x. Force to use minitest 5.x even on CI.
 
     https://github.com/KnapsackPro/knapsack/pull/114

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 2.1'
+  spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'rake', '>= 0'
 


### PR DESCRIPTION
Related to https://github.com/KnapsackPro/knapsack/pull/112

minitest 4 is bundled with Ruby 2.1

Forcing to use minitest 5 with Ruby 2.1 still causes CI build to fail https://github.com/KnapsackPro/knapsack/runs/2883581100?check_suite_focus=true

```
KNAPSACK_TEST_FILE_PATTERN="test_examples/**{,/*/**}/*_test.rb" bundle exec rake "knapsack:minitest[--verbose]"

...

/opt/hostedtoolcache/Ruby/2.1.9/x64/lib/ruby/2.1.0/minitest/unit.rb:26:in `const_missing': uninitialized constant MiniTest::Test (NameError)
	from /home/runner/work/knapsack/knapsack/lib/knapsack/adapters/minitest_adapter.rb:24:in `bind_time_tracker'
```

# Related

Support for Minitest 4 was removed in https://github.com/KnapsackPro/knapsack/pull/114

# solution

Let's use Ruby 2.2 as the minimum required version.