### PR TITLE
Avoid using fiber local for determining example group.

### DIFF
--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -10,13 +10,8 @@ module Knapsack
             Knapsack.tracker.start_timer
           end
 
-          config.prepend_before(:each) do
-            current_example_group =
-              if ::RSpec.respond_to?(:current_example)
-                ::RSpec.current_example.metadata[:example_group]
-              else
-                example.metadata
-              end
+          config.prepend_before(:each) do |example|
+            current_example_group = example.metadata[:example_group]
             Knapsack.tracker.test_path = RSpecAdapter.test_path(current_example_group)
           end
 


### PR DESCRIPTION
We ran into a problem using `Knapsack` with `Async::RSpec` which runs the spec in a nested asynchronous fiber. Because `RSpec.current_example` is fiber-local, it becomes `nil` and Knapsack fails.

In addition, it seems like the `else` side of the branch is incorrect.