### PR TITLE
Use RSpec `example` block argument instead of the global `RSpec.current_example`. This allows to run tests with the `async-rspec` gem.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 * TODO
 
-### 3.1.1
+### 4.0.0
 
-* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. This allows running tests with async-rspec gem.
+* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack/pull/107).
+* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.
 
     https://github.com/KnapsackPro/knapsack/pull/117
 
-https://github.com/KnapsackPro/knapsack/compare/v3.1.0...v3.1.1
+https://github.com/KnapsackPro/knapsack/compare/v3.1.0...v4.0.0
 
 ### 3.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * TODO
 
+### 3.1.1
+
+* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. This allows running tests with async-rspec gem.
+
+    https://github.com/KnapsackPro/knapsack/pull/117
+
+https://github.com/KnapsackPro/knapsack/compare/v3.1.0...v3.1.1
+
 ### 3.1.0
 
 * Sorting Algorithm: round robin to least connections

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### 4.0.0
 
-* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack/pull/107).
-* Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.
+* __(breaking change)__ Remove support for RSpec 2.x. This change was already done by accident in [the pull request](https://github.com/KnapsackPro/knapsack/pull/107) when we added the RSpec `context` hook, which is available only since RSpec 3.x.
+* Use RSpec `example` block argument instead of the global `RSpec.current_example`. This allows to run tests with the `async-rspec` gem.
 
     https://github.com/KnapsackPro/knapsack/pull/117
 

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake', '>= 0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
-  spec.add_development_dependency 'rspec', '~> 3.0', '>= 2.10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.3'
   spec.add_development_dependency 'cucumber', '>= 0'
   spec.add_development_dependency 'spinach', '>= 0.8'

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -15,6 +15,7 @@ module Knapsack
               if ::RSpec.respond_to?(:current_example)
                 ::RSpec.current_example.metadata[:example_group]
               else
+                # support for an old RSpec 2.x version
                 example.metadata
               end
             Knapsack.tracker.test_path = RSpecAdapter.test_path(current_example_group)

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -10,15 +10,8 @@ module Knapsack
             Knapsack.tracker.start_timer
           end
 
-          config.prepend_before(:each) do
-            current_example_group =
-              if ::RSpec.respond_to?(:current_example)
-                ::RSpec.current_example.metadata[:example_group]
-              else
-                # support for an old RSpec 2.x version
-                example.metadata
-              end
-            Knapsack.tracker.test_path = RSpecAdapter.test_path(current_example_group)
+          config.prepend_before(:each) do |example|
+            Knapsack.tracker.test_path = RSpecAdapter.test_path(example)
           end
 
           config.append_after(:context) do
@@ -51,7 +44,15 @@ module Knapsack
         end
       end
 
-      def self.test_path(example_group)
+      def self.test_path(example)
+        example_group =
+          if Gem::Version.new(::RSpec::Core::Version::STRING) < Gem::Version.new('3.0.0')
+            # support for an old RSpec 2.x version
+            example.metadata
+          else
+            example.metadata[:example_group]
+          end
+
         if defined?(::Turnip) && Gem::Version.new(::Turnip::VERSION) < Gem::Version.new('2.0.0')
           unless example_group[:turnip]
             until example_group[:parent_example_group].nil?

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -52,7 +52,7 @@ module Knapsack
       end
 
       def self.test_path(example_group)
-        if defined?(Turnip) && Turnip::VERSION.to_i < 2
+        if defined?(::Turnip) && Gem::Version.new(::Turnip::VERSION) < Gem::Version.new('2.0.0')
           unless example_group[:turnip]
             until example_group[:parent_example_group].nil?
               example_group = example_group[:parent_example_group]

--- a/lib/knapsack/adapters/rspec_adapter.rb
+++ b/lib/knapsack/adapters/rspec_adapter.rb
@@ -45,13 +45,7 @@ module Knapsack
       end
 
       def self.test_path(example)
-        example_group =
-          if Gem::Version.new(::RSpec::Core::Version::STRING) < Gem::Version.new('3.0.0')
-            # support for an old RSpec 2.x version
-            example.metadata
-          else
-            example.metadata[:example_group]
-          end
+        example_group = example.metadata[:example_group]
 
         if defined?(::Turnip) && Gem::Version.new(::Turnip::VERSION) < Gem::Version.new('2.0.0')
           unless example_group[:turnip]

--- a/spec/knapsack/adapters/rspec_adapter_spec.rb
+++ b/spec/knapsack/adapters/rspec_adapter_spec.rb
@@ -16,22 +16,16 @@ describe Knapsack::Adapters::RSpecAdapter do
       let(:tracker) { instance_double(Knapsack::Tracker) }
       let(:test_path) { 'spec/a_spec.rb' }
       let(:global_time) { 'Global time: 01m 05s' }
-      let(:example_group) { double }
-      let(:current_example) do
-        OpenStruct.new(metadata: {
-          example_group: example_group
-        })
-      end
+      let(:current_example) { double }
 
       it do
         expect(config).to receive(:prepend_before).with(:context).and_yield
-        expect(config).to receive(:prepend_before).with(:each).and_yield
+        expect(config).to receive(:prepend_before).with(:each).and_yield(current_example)
         expect(config).to receive(:append_after).with(:context).and_yield
         expect(config).to receive(:after).with(:suite).and_yield
         expect(::RSpec).to receive(:configure).and_yield(config)
 
-        expect(::RSpec).to receive(:current_example).twice.and_return(current_example)
-        expect(described_class).to receive(:test_path).with(example_group).and_return(test_path)
+        expect(described_class).to receive(:test_path).with(current_example).and_return(test_path)
 
         allow(Knapsack).to receive(:tracker).and_return(tracker)
         expect(tracker).to receive(:start_timer).ordered
@@ -81,7 +75,7 @@ describe Knapsack::Adapters::RSpecAdapter do
   end
 
   describe '.test_path' do
-    let(:current_example_metadata) do
+    let(:example_group) do
       {
           file_path: '1_shared_example.rb',
           parent_example_group: {
@@ -92,14 +86,19 @@ describe Knapsack::Adapters::RSpecAdapter do
           }
       }
     end
+    let(:current_example) do
+      OpenStruct.new(metadata: {
+        example_group: example_group
+      })
+    end
 
-    subject { described_class.test_path(current_example_metadata) }
+    subject { described_class.test_path(current_example) }
 
     it { should eql 'a_spec.rb' }
 
     context 'with turnip features' do
       describe 'when the turnip version is less than 2' do
-        let(:current_example_metadata) do
+        let(:example_group) do
           {
             file_path: "./spec/features/logging_in.feature",
             turnip: true,
@@ -115,7 +114,7 @@ describe Knapsack::Adapters::RSpecAdapter do
       end
 
       describe 'when turnip is version 2 or greater' do
-        let(:current_example_metadata) do
+        let(:example_group) do
           {
             file_path: "gems/turnip-2.0.0/lib/turnip/rspec.rb",
             turnip: true,


### PR DESCRIPTION
Use RSpec `example` from RSpec `each` hook instead of global `RSpec.current_example`. It allows running tests with async-rspec gem.

# Related
https://github.com/KnapsackPro/knapsack/pull/116

# details

I noticed when I downgrade RSpec to 2.x version in the example repo https://github.com/KnapsackPro/rails-app-with-knapsack then we can't record tests due to bug:

```
rails-app-with-knapsack rspec-current-example-group! ruby-3.0.1
$ KNAPSACK_GENERATE_REPORT=true bundle exec rspec spec
Knapsack report generator started!
/Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:512:in `extract_scope_from': You must explicitly give a scope (:each, :all, or :suite) when using symbols as metadata for a hook. (ArgumentError)
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:505:in `scope_and_options_from'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:483:in `register_hook'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/hooks.rb:328:in `prepend_before'
	from /Users/artur/Documents/github/knapsack-pro/knapsack/lib/knapsack/adapters/rspec_adapter.rb:9:in `block in bind_time_tracker'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core.rb:154:in `configure'
	from /Users/artur/Documents/github/knapsack-pro/knapsack/lib/knapsack/adapters/rspec_adapter.rb:8:in `bind_time_tracker'
	from /Users/artur/Documents/github/knapsack-pro/knapsack/lib/knapsack/adapters/base_adapter.rb:19:in `bind'
	from /Users/artur/Documents/github/knapsack-pro/knapsack/lib/knapsack/adapters/base_adapter.rb:10:in `bind'
	from /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack/spec/spec_helper.rb:8:in `<top (required)>'
	from /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack/spec/rails_helper.rb:3:in `require'
	from /Users/artur/Documents/github/knapsack-pro/rails-app-with-knapsack/spec/rails_helper.rb:3:in `<top (required)>'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1036:in `require'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1036:in `block in setup_load_path_and_require'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1036:in `each'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/configuration.rb:1036:in `setup_load_path_and_require'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/configuration_options.rb:25:in `configure'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/command_line.rb:17:in `run'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:103:in `run'
	from /Users/artur/.rvm/gems/ruby-3.0.1/gems/rspec-core-2.99.2/lib/rspec/core/runner.rb:17:in `block in autorun'
```

It looks like we introduced breaking change for  RSpec 2.x when we added `context` hook in PR https://github.com/KnapsackPro/knapsack/pull/107

# changes

* As part of this PR we drop support for RSpec 2.x
* we added support for async-rspec gem