### PR TITLE
Explicitly depend on racc to fix specs for Ruby 3.3+

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in knapsack.gemspec
 gemspec
-
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
-  gem "racc", ">= 1.7.3"
-end

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in knapsack.gemspec
 gemspec
+
+if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.3.0")
+  gem "racc", ">= 1.7.3"
+end

--- a/knapsack.gemspec
+++ b/knapsack.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'spinach', '>= 0.8'
   spec.add_development_dependency 'minitest', '>= 5.0.0'
   spec.add_development_dependency 'pry', '~> 0'
+  spec.add_development_dependency 'racc', '>= 0'
   spec.add_development_dependency 'timecop', '>= 0.9.4'
 end


### PR DESCRIPTION
On Ruby 3.3.0-preview3, knapsack's own specs fail:

```
$ ruby -v
ruby 3.3.0dev (2023-11-12 master 60e19a0b5f) [x86_64-darwin23]

$ bundle exec rspec spec
An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require 'spinach'

LoadError:
  cannot load such file -- racc/parser.rb
```

This is because in Ruby 3.3, the racc gem is no longer a default gem. This change is mentioned in the [Ruby 3.3.0-preview2 release notes](https://www.ruby-lang.org/en/news/2023/09/14/ruby-3-3-0-preview2-released/):

> The following default gem is now bundled.
> racc 1.7.1

Since knapsack's specs rely on the racc gem being present, this means that in Ruby 3.3 racc must be explicitly declared as a development dependency in the Gemfile.

This commit adds the racc dependency, ~conditionally based on the Ruby version~. With this change, the specs now pass.

```
$ ruby -v
ruby 3.3.0dev (2023-11-12 master 60e19a0b5f) [x86_64-darwin23]

$ bundle exec rspec spec
...
Finished in 1.91 seconds (files took 0.42586 seconds to load)
210 examples, 0 failures
```